### PR TITLE
[BUGFIX] Adapte the .gitignore to don't have the pycharm folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 **/__pycache__/
+.idea/
+.DS_Store/


### PR DESCRIPTION
## Problem
When using PyCharm, the software creates a folder ".idea", with all settings for the project, including the environnement to run, and other settings.

## Solution
To complet the .gitignore to include the not accept files.
