### PR TITLE
[FEATURE] Add an indicator to show if the bnote is controlling in remote ssh

### DIFF
--- a/bnote/__init__.py
+++ b/bnote/__init__.py
@@ -12,6 +12,9 @@
  Version in anothers forms are not tolerate !
  '''
 
+import os
 from bnote.tools.yaupdater import YAUpdater
 
 __version__ = YAUpdater.get_version_from_running_project("pyproject.toml")
+if 'PYCHARM_HOSTED' in os.environ or 'SSH_CLIENT' in os.environ or 'SSH_TTY' in os.environ:
+    __version__+=" Remote"


### PR DESCRIPTION
## Problem
There are not an indication on the bnote when the code is execute from PyCharm or a computer connecting in ssh.

### Solution
Add the information on the variable __version in __init__.

###Information
The check update is not impacted.