### PR TITLE
[BUGFIX] Resolve the crash with the text bluetooth send

### DIFF
--- a/bnote/apps/edt/editor_app.py
+++ b/bnote/apps/edt/editor_app.py
@@ -179,7 +179,7 @@ class EditorApp(EditorBaseApp):
         self._current_dialog = ui.UiInfoDialogBox(message=messages[activity], action=self._exec_cancel_dialog)
 
     def _exec_send_to(self):
-        if not self.__dialog_is_reading_file():
+        if not self._EditorBaseApp__dialog_is_reading_file():
             if not len(BnoteApp.bluetooth_devices):
                 self._current_dialog = ui.UiInfoDialogBox(message=_("not device connected"), action=self._exec_cancel_dialog)
                 return


### PR DESCRIPTION
## Problème
There was a crash when goto the option to send a text by bluetooth in the editor;

## Solution
Correct the function call.