### PR TITLE
[FEATURE] Open update files when there are in the bluetooth folder

### DIFF
--- a/bnote/apps/fman/file_manager_app.py
+++ b/bnote/apps/fman/file_manager_app.py
@@ -2124,6 +2124,20 @@ class FileManagerApp(BnoteApp):
             if focused_file.is_dir():
                 self.__init_new_current_folder_and_build_braille_line(focused_file)
             elif focused_file.is_file():
+                if str(focused_file).endswith(".whl.zip") and not str(self.__current_folder).startswith(str(FileManager.get_backup_path())) and not str(self.__current_folder).startswith(str(Trash.get_trash_path())):
+                    bnote_whl_file, version = YAUpdater.get_version(focused_file)
+                    if version != "":
+                        self._current_dialog = ui.UiMessageDialogBox(
+                            name=_("information"),
+                            message=_("do you want to install the version {} ?").format(version),
+                            buttons=[
+                                ui.UiButton(name=_("&yes"), action=self._exec_install_version_with_yaupdater,
+                                            action_param={"file": focused_file}),
+                                ui.UiButton(name=_("&no"), action=self._exec_cancel_dialog),
+                            ],
+                            action_cancelable=self._exec_cancel_dialog,
+                        )
+                        return
                 if str(self.__current_folder).startswith(str(FileManager.get_bluetooth_path())) or \
                         str(self.__current_folder).startswith(str(FileManager.get_backup_path())) or \
                         str(self.__current_folder).startswith(str(Trash.get_trash_path())):
@@ -2173,20 +2187,6 @@ class FileManagerApp(BnoteApp):
                 elif extension in Mp3App.known_extension():
                     RecentFile().add_file_to_list(focused_file.name, focused_file)
                     self.__activate_mp3_apps(**{'filename': focused_file})
-                elif str(focused_file).endswith(".whl.zip"):
-                    bnote_whl_file, version = YAUpdater.get_version(focused_file)
-                    if version != "":
-                        self._current_dialog = ui.UiMessageDialogBox(
-                            name=_("information"),
-                            message=_("do you want to install the version {} ?").format(version),
-                            buttons=[
-                                ui.UiButton(name=_("&yes"), action=self._exec_install_version_with_yaupdater,
-                                            action_param={"file": focused_file}),
-                                ui.UiButton(name=_("&no"), action=self._exec_cancel_dialog),
-                            ],
-                            action_cancelable=self._exec_cancel_dialog,
-                        )
-                        return
                 elif extension == ".zip":
                     self._current_dialog=ui.UiMessageDialogBox(
                         name=_("unzip"),

--- a/bnote/tools/yaupdater.py
+++ b/bnote/tools/yaupdater.py
@@ -87,7 +87,7 @@ class YAUpdater:
                     if bnote_whl_file:
                         log.error(f"{bnote_whl_file.stem=}")
                         # DP FIXME La version retournée est celle du nom de fichier, on pourrait aller chercher le fichier file.distinfo/METADATA ligne version=
-                        pattern_version = r'bnote-(?P<version>[0-9]\.[0-9]\.[0-9]?(a|b|rc)?\d+)-py3-none-any'
+                        pattern_version = r'bnote-(?P<version>[0-9]+\.[0-9]+\.[0-9]+(a|b|rc)?\d*)-py3-none-any'
                         match = re.match(pattern_version, str(bnote_whl_file.stem))
                         if match:
                             if 'version' in match.groupdict().keys() and match.group('version'):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bnote"
-version = "3.0.4"
+version = "3.0.100"
 description = "bnote application"
 authors = [{name = "Eurobraille team"}]
 requires-python = ">=3.11, <3.12"


### PR DESCRIPTION
## Problem
In the previous versions, user could opening an update file in the bluetooth. With the new version it's not possible.

## Solution
Adjust the authorization to accept the update file.

## For testing
- Upload sources on B.note,
- Start this apps version,
- Send an update by Bluetooth,
- Check in the explorer that the dialog box to install the update is open when you open the update in the bluetooth folder.