### PR TITLE
[FEATURE] Use the release system of GitHub to manage versions

### DIFF
--- a/bnote/apps/settings/settings_app.py
+++ b/bnote/apps/settings/settings_app.py
@@ -1986,7 +1986,7 @@ class SettingsApp(BnoteApp):
         )
 
     def _exec_yes_install(self):
-        file = f"{UPDATE_FOLDER_URL}/{self.update.file_to_install}"
+        file = self.update.file_to_install
         self._current_dialog = ui.UiInfoDialogBox(_("downloading..."))
         YAUpdater(file, "/home/pi/all_bnotes/", self.refresh_install_message, self.yaupdater_ended)
 

--- a/bnote/apps/settings/settings_app.py
+++ b/bnote/apps/settings/settings_app.py
@@ -29,7 +29,8 @@ from bnote.tools.quick_search import QuickSearch
 from bnote.tools.settings import Settings, BLUETOOTH_BASE_NAME
 from bnote.tools.sync_date import SyncDate
 from bnote.tools.translate import Translate
-from bnote.tools.yaupdater import UPDATE_FOLDER_URL, YAUpdater, YAUpdaterFinder, YAVersionFinder
+from bnote.tools.yaupdater import UPDATE_FOLDER_URL, YAUpdater, YAUpdaterFinder, YAVersionFinder, test_new_source, \
+    change_update_source
 from bnote.tools.volume import Volume
 from bnote.tools.volume_speed_dialog_box import VolumeDialogBox, SpeedDialogBox
 from bnote.tools.io_util import Gpio
@@ -228,6 +229,7 @@ class SettingsApp(BnoteApp):
             ('stm32', 'standby_transport'): {'action': self.__dialog_set_stm32, 'action_param': {'section': 'stm32', 'key': 'standby_transport'}},
             ('stm32', 'standby_shutdown'): {'action': self.__dialog_set_stm32, 'action_param': {'section': 'stm32', 'key': 'standby_shutdown'}},
             # ('update', 'auto_check'): {'action': self.__dialog_set_settings, 'action_param': {'section': 'update', 'key': 'auto_check'}},
+            ('update', 'search_update_to'): {'action': self._exec_change_update_source, 'action_param': {'section': 'update, source'}},
             ('version', 'application'): {'action': self.__dialog_application_version, 'action_param': {'section': 'version', 'key': 'application'}},
         }
 
@@ -438,6 +440,7 @@ class SettingsApp(BnoteApp):
                     menu_item_list=[
                         ui.UiMenuItem(name=_("check update"), action=self._exec_check_update),
                         ui.UiMenuItem(name=_("&install an other version"), action=self._exec_get_update_history),
+                        ui.UiMenuItem(name=_("search update to"), **self.__action_and_action_param[('update', 'search_update_to')]),
                         # FIXME auto_check affiche un message à chaque fois que l'on rentre dans les préférences pour dire "système à jour", il est trop bavard.
                         # FIXME Il faudrait que ce soit fait dans internal pour que quelqu'un qui ne rentre pas dans les préférences soit prévenu.
                         # ui.UiMenuItem(name=_("&auto check"), **self.__action_and_action_param[('update', 'auto_check')]),
@@ -713,6 +716,7 @@ class SettingsApp(BnoteApp):
             self.__append_line_in_document(param_label=_("update available"), param_value=version_to_install)
         else:
             self.__append_line_in_document(param_label=_("your b.note is up to date"))
+        self.__append_line_in_document(param_label=_("update source"), param_value=Settings().data['update']['search_update_to'], dialog_box_name=_("update"), dialog_box_param_name=_("source"), section='update', key='search_update_to')
         # Versions
         self.__append_line_in_document()
         self.__append_line_in_document(param_label=_("versions"), is_tab_stop=True)
@@ -2039,6 +2043,7 @@ class SettingsApp(BnoteApp):
             return
         elif not self.update.files:
             self._current_dialog=UiInfoDialogBox(message=_("No version available through this source."), action=self._exec_cancel_dialog)
+            return
         update_list = []
         for version in self.update.files:
             update_list.append(version['version'])
@@ -2580,6 +2585,37 @@ class SettingsApp(BnoteApp):
 
     def _update_menu_items(self):
         pass
+
+    def _exec_change_update_source(self, **kwargs):
+        actual_source = Settings().data['update']['search_update_to']
+        self._current_dialog=ui.UiDialogBox(
+            name=_("update source"),
+            item_list=[
+                ui.UiEditBox(name=_("source &url"), value=("url", actual_source)),
+                ui.UiButton(name=_("&ok"), action=self._exec_valid_change_update_source),
+                ui.UiButton(name=_("&set default"), action=self._exec_set_default_source),
+                ui.UiButton(name=_("&cancel"), action=self._exec_cancel_dialog),
+            ],
+            action_cancelable=self._exec_cancel_dialog
+        )
+
+    def _exec_set_default_source(self):
+        Settings().data['update']['search_update_to'] = Settings().DEFAULT_VALUES['update']['search_update_to']
+        Settings().save()
+        self._put_in_function_queue(FunctionId.FUNCTION_SETTINGS_CHANGE, **{'section': 'update', 'key': 'search_update_to'})
+        change_update_source()
+
+    def _exec_valid_change_update_source(self):
+        kwargs=self._current_dialog.get_values()
+        new_source = kwargs['url']
+        if test_new_source(new_source):
+            Settings().data['update']['search_update_to'] = new_source
+            Settings().save()
+            self._put_in_function_queue(FunctionId.FUNCTION_SETTINGS_CHANGE, **{'section': 'update', 'key': 'search_update_to'})
+            change_update_source()
+            return True
+        else:
+            self._current_dialog=UiInfoDialogBox(message=_("source not valid..."), action=self._exec_change_update_source)
 
     def __dialog_application_version(self, section, key, **kwargs):
         versions = YAVersionFinder.find_versions()

--- a/bnote/tools/settings.py
+++ b/bnote/tools/settings.py
@@ -111,7 +111,7 @@ class Settings(metaclass=SingletonMeta):
                                                     'use_vocal': "auto",
                                                     'keep_spaces': False,
                                                     'write_all': True},
-                               'update': {'auto_check': False},
+                               'update': {'auto_check': False, 'search_update_to': 'https://api.github.com/repos/devel-erb/bnote/releases'},
                                'eole': {'user_name': '', 'token': ''},
                                'translator': {
                                    'base_language': "French",
@@ -203,7 +203,7 @@ class Settings(metaclass=SingletonMeta):
                                                   'use_vocal': ("auto", "ask", "no"),
                                                   'keep_spaces': (True, False),
                                                   'write_all': (True, False)},
-                             'update': {'auto_check': (True, False)},
+                             'update': {'auto_check': (True, False), 'search_update_to': 'https://api.github.com/repos/devel-erb/bnote/releases'},
                              'eole': {'user_name': '', 'token': ''},
                              'stm32': {'name': '',
                                        'len': range(0, 81),

--- a/bnote/tools/yaupdater.py
+++ b/bnote/tools/yaupdater.py
@@ -21,14 +21,29 @@ import pkg_resources
 
 
 from bnote.debug.colored_log import ColoredLogger, YAUPDATER_LOG
+from bnote.tools.settings import Settings
 
 log = ColoredLogger(__name__)
 log.setLevel(YAUPDATER_LOG)
 
 # UPDATE_FOLDER_URL = 'https://update.eurobraille.fr/radio/download/bnote/bnote3.x.x'
-UPDATE_FOLDER_URL = 'https://api.github.com/repos/theotime2005/bnote/releases'
+UPDATE_FOLDER_URL = Settings().data['update']['search_update_to']
 INSTALL_FOLDER = Path("/home/pi/all_bnotes")
 
+def test_new_source(source) -> bool:
+    """
+    Return True if the link is a valid source.
+    :param source: the link to test.
+    :return: Boolean
+    """
+    response = requests.get(source)
+    if response.status_code==200 and "bnote" in source:
+        return True
+    return False
+
+def change_update_source():
+    global UPDATE_FOLDER_URL
+    UPDATE_FOLDER_URL = Settings().data['update']['search_update_to']
 
 # Objectifs :
 # - Installer une version de bnote à partir d'un tar.gz créé par poetry
@@ -391,7 +406,7 @@ class YAUpdaterFinder:
             for release in releases:
                 # Get the link only for the update
                 for asset in release['assets']:
-                    if asset['content-type']=="application/zip":
+                    if asset['content_type']=="application/zip":
                         file_link = asset['browser_download_url']
                 if not file_link:
                     self.version_to_install="failed"

--- a/bnote/tools/yaupdater.py
+++ b/bnote/tools/yaupdater.py
@@ -387,14 +387,24 @@ class YAUpdaterFinder:
             releases = response.json()
             current_version = YAUpdater.get_version_from_running_project("pyproject.toml")
 
+            file_link =None
             for release in releases:
+                # Get the link only for the update
+                for asset in release['assets']:
+                    if asset['content-type']=="application/zip":
+                        file_link = asset['browser_download_url']
+                if not file_link:
+                    self.version_to_install="failed"
+                    return
                 file_version = release['tag_name']
                 if file_version.startswith('v'):
                     file_version = file_version[1:]
-                if self.is_allowed_version(file_version) and not self.is_first_str_version_greater_or_equal(current_version, file_version):
-                    if file_to_install is None or not self.is_first_str_version_greater_or_equal(version_to_install, file_version):
-                        version_to_install = file_version
-                        file_to_install = release['assets'][0]['browser_download_url']
+                if self.is_allowed_version(file_version):
+                    files.append({'version': file_version, 'link': file_link})
+                    if not self.is_first_str_version_greater_or_equal(current_version, file_version):
+                        if file_to_install is None or not self.is_first_str_version_greater_or_equal(version_to_install, file_version):
+                            version_to_install = file_version
+                            file_to_install = file_link
         except requests.exceptions.RequestException as err:
             print(f"Request error: {err}")
             version_to_install = 'failed'


### PR DESCRIPTION
## Problem
Using web scraping can be tricky, especially if there are file errors or x reasons. The parsing of the html page can be wrong and the page itself is not very accessible.

## Solution
Use GitHub releases in combination with the API for better performance. This makes it possible to have a json object that is easy to manipulate, which makes the code more readable.

## Note
- We could choose the update channel in the settings,
- The API could be used on the Eurobraille site in order to always have the latest version available without having to modify it.