### PR TITLE
[BUGFIX] Update the braille type and the translation of all items in main menu

### DIFF
--- a/bnote/apps/internal.py
+++ b/bnote/apps/internal.py
@@ -265,6 +265,15 @@ class Internal:
             if not ((key in self.apps_editor) or (key in self.apps_bluetooth) or (key == 'usb_1') or (key == 'usb_2')):
                 # Retranslate all menu app items except editor, bluetooth and usb apps.
                 self._menu.rename_item(self.__app_translate(key), braille_type, app_descriptor.action)
+        usb_1 = self._menu.get_object(self._exec_usb_1).name()
+        if "usb" in usb_1:
+            self._menu.rename_item(_("usb_&a"), braille_type, self._exec_usb_1)
+        usb_2 = self._menu.get_object(self._exec_usb_2).name()
+        if "usb" in usb_2:
+            self._menu.rename_item(_("usb_&b"), braille_type, self._exec_usb_2)
+        # Translate transport and shutdown
+        self._menu.rename_item(_("transport"), braille_type, self._exec_ask_transport)
+        self._menu.rename_item(_("shutdown"), braille_type, self._exec_ask_shutdown)
         # Translate each app.
         for descriptor in self.apps_descriptor.values():
             app = descriptor.instance

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bnote"
-version = "3.0.100"
+version = "3.0.4"
 description = "bnote application"
 authors = [{name = "Eurobraille team"}]
 requires-python = ">=3.11, <3.12"


### PR DESCRIPTION
## Problem

When changing the language or type of braille, the transport and extinction elements were not updated.

## Solution

Manually update the items in the translate_ui function of the internal file.

#### Note

The version number was changed by a previous pull request, I restored it to 3.0.4 until the next version of the repository.