### PR TITLE
[FEATURE] Migrate old settings if values change

### DIFF
--- a/bnote/tools/settings.py
+++ b/bnote/tools/settings.py
@@ -260,6 +260,8 @@ class Settings(metaclass=SingletonMeta):
 
         # print(f"{self.data=}")
         # print(f"{len(self.data)=}")
+        # Check migration
+        self.migrate_settings()
 
         # Save the data to reflect the possible change from setdefault()
         self.save()
@@ -295,3 +297,15 @@ class Settings(metaclass=SingletonMeta):
         self.save()
         self.load()
         return True
+
+    def migrate_settings(self):
+        """
+        If settings value has change, they must be change here
+        """
+        must_save = False
+        # Agenda has change not done to not_done
+        if self.data['agenda']['default_presentation']=="not done":
+            self.data['agenda']['default_presentation']="not_done"
+            must_save = True
+        # Add other changements here
+        return must_save


### PR DESCRIPTION
## Problem

If you decide for one reason or another to change the value of a parameter, for example in pull request #17, there is no way to inform the user since this is done in back.

## Solution

Add a migration function in which, for each modified parameter, we put a condition that will update this parameter in the user file if it is set to the old version.