### PR TITLE
[FEATURE] Add a button to switch version into the about dialog

### DIFF
--- a/bnote/apps/settings/settings_app.py
+++ b/bnote/apps/settings/settings_app.py
@@ -4096,6 +4096,8 @@ class SettingsApp(BnoteApp):
                     value=("eurobraille", document_eurobraille),
                     is_read_only=True,
                 ),
+                # Add a button to switch version
+                ui.UiButton(name=_("&switch version"), action=self.__dialog_application_version, action_param={'section': 'version', 'key': 'application'}),
                 ui.UiButton(name=_("&close"), action=self._exec_cancel_dialog),
             ],
             action_cancelable=self._exec_cancel_dialog,


### PR DESCRIPTION
This pull request to `bnote/apps/settings/settings_app.py` includes a small but significant change to the settings application. The change adds a new button to the user interface.

* Added a new `UiButton` to allow users to switch the application version in the `_exec_about_bnote` method.