### PR TITLE
[FEATURE] Add a dialogue box to display the properties of a file or folder

### DIFF
--- a/bnote/apps/fman/file_manager_app.py
+++ b/bnote/apps/fman/file_manager_app.py
@@ -10,7 +10,6 @@ import os
 import threading
 import time
 from pathlib import Path
-
 from bnote.apps.ai_assistant.ai_assistant_app import AiAssistantApp
 from bnote.apps.edt.editor_app import EditorApp
 from bnote.apps.eole.eole_api import EoleApi
@@ -203,6 +202,12 @@ class FileManagerApp(BnoteApp):
                     action=self._exec_find_file,
                     shortcut_modifier=Keyboard.BrailleModifier.BRAILLE_FLAG_CTRL,
                     shortcut_key="F",
+                ),
+                ui.UiMenuItem(
+                    name=_("pro&perties"),
+                    action=self._exec_properties,
+                    shortcut_modifier=Keyboard.BrailleModifier.BRAILLE_FLAG_NONE,
+                    shortcut_key=Keyboard.BrailleFunction.BRAMIGRAPH_F1,
                 ),
             ],
         )
@@ -1122,6 +1127,78 @@ class FileManagerApp(BnoteApp):
         if file_lst:
             return file_lst
         return False
+
+    def _exec_properties(self):
+        if not os.listdir(self.__current_folder) or len(self.__selected_files)!=1:
+            return
+        focused_file = self.__files[self.__focused_file_index]
+        properties = focused_file.stat()
+
+        # Calcul de la taille en Mo, Go
+        size_bytes = properties.st_size
+        if size_bytes < 1024:
+            size_formatted = "".join((f"{size_bytes} ", _("bytes")))
+        elif size_bytes < 1024**2:
+            size_formatted = "".join((f"{size_bytes / 1024:.2f} ", _("Kb")))
+        elif size_bytes < 1024**3:
+            size_formatted = "".join((f"{size_bytes / 1024 ** 2:.2f} ", _("Mb")))
+        else:
+            size_formatted = "".join((f"{size_bytes / 1024 ** 3:.2f} ", _("Gb")))
+
+        # Determined type
+        extension = ""
+        if focused_file.is_dir():
+            item_type = _("folder")
+        else:
+            extension = focused_file.suffix
+            if extension in EditorApp.known_extension():
+                item_type = _("editor file")
+            elif extension in Mp3App.known_extension():
+                item_type = _("audio file")
+            elif extension in MusicApp.known_extension():
+                item_type = _("music file")
+            else:
+                item_type = _("file not suported")
+
+        properties_infos = {
+            "name": focused_file.name,
+            "type": item_type if focused_file.is_dir() else f"{item_type} {extension}",
+            "size": size_formatted,
+            "last_modification": datetime.datetime.fromtimestamp(properties.st_mtime),
+            "creation_date": datetime.datetime.fromtimestamp(properties.st_ctime),
+        }
+        translation = {
+            "name": _("name"),
+            "type": _("type"),
+            "size": _("size"),
+            "last_modification": _("last modification"),
+            "creation_date": _("creation date"),
+            "child_number": _("child"),
+        }
+        # Add child number if it's a folder
+        if focused_file.is_dir():
+            properties_infos["child_number"] = len(
+                FileManagerApp.__list_dir(focused_file)
+            )
+
+        properties_documens = ""
+        for item in properties_infos:
+            properties_documens += f"{translation[item]}: {properties_infos[item]}\n"
+        # Retirer le dernier \n du document
+        properties_documens = properties_documens[:-1]
+        self._current_dialog = ui.UiDialogBox(
+            name=_("properties"),
+            item_list=[
+                ui.UiMultiLinesBox(
+                    name=_("Click to show properties"),
+                    value=("properties", properties_documens),
+                    no_grade=True,
+                    is_read_only=True,
+                ),
+                ui.UiButton(name=_("&close"), action=self._exec_cancel_dialog),
+            ],
+            action_cancelable=self._exec_cancel_dialog,
+        )
 
     def _exec_show_in_folder(self, folder, open=False):
         kwargs = self._current_dialog.get_values()


### PR DESCRIPTION
This pull request introduces a new "Properties" feature to the file manager application, allowing users to view detailed information about a selected file or folder. The changes include adding a new menu item for accessing the properties and implementing the logic to calculate and display file or folder properties in a dialog box.

### New "Properties" Feature:

* **Added a "Properties" menu item**:
  - A new `UiMenuItem` for "Properties" was added to the file manager's file menu, enabling users to access the properties of the currently focused file or folder. (`bnote/apps/fman/file_manager_app.py`, [bnote/apps/fman/file_manager_app.pyR206-R211](diffhunk://#diff-c9d50143217f8cc9fa7ed41923e40d04d234da688b62037ee95f0ec3b1e8cc79R206-R211))

* **Implemented `_exec_properties` method**:
  - This method calculates and displays detailed properties of the selected file or folder, such as name, type, size (formatted in bytes, KB, MB, or GB), last modification date, creation date, and the number of child items (for folders). The information is presented in a read-only dialog box. (`bnote/apps/fman/file_manager_app.py`, [bnote/apps/fman/file_manager_app.pyR1131-R1202](diffhunk://#diff-c9d50143217f8cc9fa7ed41923e40d04d234da688b62037ee95f0ec3b1e8cc79R1131-R1202))

### Code Cleanup:

* **Removed unused import**:
  - The unused `threading` import was removed to clean up the code. (`bnote/apps/fman/file_manager_app.py`, [bnote/apps/fman/file_manager_app.pyL13](diffhunk://#diff-c9d50143217f8cc9fa7ed41923e40d04d234da688b62037ee95f0ec3b1e8cc79L13))