### PR TITLE
feat: Add a progress indicator in the brf exportation

### DIFF
--- a/bnote/apps/edt/editor_app.py
+++ b/bnote/apps/edt/editor_app.py
@@ -214,7 +214,7 @@ class EditorApp(EditorBaseApp):
             braille_language = (
                 braille_device_characteristics.get_keyboard_language_country()
             )
-        self._current_dialog = ui.UiInfoDialogBox(_("exporting..."))
+        self._current_dialog = ui.UiInfoDialogBox(_("loading..."))
         try:
             line_length = int(kwargs["line"])
             page_line = int(kwargs["page"])
@@ -232,9 +232,13 @@ class EditorApp(EditorBaseApp):
             file,
             first_page,
             language_encoding,
+            self._exec_on_export_progress,
             self._exec_end_export,
         )
         export.start()
+
+    def _exec_on_export_progress(self, progress):
+        self._current_dialog=ui.UiInfoDialogBox(_("exporting {}%").format(progress))
 
     def _exec_end_export(self, activity):
         messages = {

--- a/bnote/apps/edt/edt/write_brf_file.py
+++ b/bnote/apps/edt/edt/write_brf_file.py
@@ -24,7 +24,8 @@ class WriteBrfFile(threading.Thread):
         max_page,
         first_page,
         braille_table,
-        on_end,
+        on_progress_function=None,
+        on_end=None,
     ):
         threading.Thread.__init__(self)
         self._get_line = get_line
@@ -41,14 +42,33 @@ class WriteBrfFile(threading.Thread):
         self.first_page = []
         self.page_document = []
         self.braille_table = braille_table
-        self.on_end = on_end
+        # Backward compatibility: old callers passed only the end callback here.
+        if on_end is None and callable(on_progress_function):
+            self.on_progress_function = None
+            self.on_end = on_progress_function
+        else:
+            self.on_progress_function = on_progress_function
+            self.on_end = on_end
+        self._last_progress = -1
 
     def run(self) -> None:
+        self._notify_progress_if_increased(0)
         self.get_title(self.first_origine_first_page)
+        self._notify_progress_if_increased(5)
         document_original = self.import_and_convert_file()
         self.page_document = self._cut_document(document_original)
+        self._notify_progress_if_increased(90)
         self._get_volume()
+        self._notify_progress_if_increased(95)
         self.construct_document()
+
+    def _notify_progress_if_increased(self, percent):
+        percent = max(0, min(100, int(percent)))
+        if percent <= self._last_progress:
+            return
+        self._last_progress = percent
+        if callable(self.on_progress_function):
+            self.on_progress_function(percent)
 
     def get_title(self, first_page):
         page = first_page.split("\n")[1:]
@@ -62,22 +82,32 @@ class WriteBrfFile(threading.Thread):
         file_convert = []
         if self._get_line is None:
             raise IOError("Error during editor access")
+        raw_lines = []
         cnt = 0
         while True:
             line = self._get_line(cnt)
             if line is None:
                 # last line reached.
                 break
-            line_convert = self.delete_strange_characters(line)
+            raw_lines.append(self.delete_strange_characters(line))
+            # Next line.
+            cnt += 1
+
+        total_lines = len(raw_lines)
+        if total_lines == 0:
+            self._notify_progress_if_increased(85)
+            return file_convert
+
+        for index, line_convert in enumerate(raw_lines, start=1):
             file_convert.append(
                 Lou(self.language).convert_to_braille(self.braille_type, line_convert)[
                     1
                 ]
             )
+            progress = 5 + int((index * 80) / total_lines)
+            self._notify_progress_if_increased(progress)
             # Just to let others threads running.
             time.sleep(0.001)
-            # Next line.
-            cnt += 1
         return file_convert
 
     @staticmethod
@@ -169,16 +199,20 @@ class WriteBrfFile(threading.Thread):
                 self.on_end("exist")
                 return False
             cpt = 1
+            total_volumes = len(self.braille_document)
             for volume in self.braille_document:
                 name_file = _("Volume {}").format(cpt)
                 self._create_file(volume, "{}/{}.brf".format(folder_name, name_file))
+                self._notify_progress_if_increased(95 + int((cpt * 5) / total_volumes))
                 cpt += 1
+            self._notify_progress_if_increased(100)
             self.on_end("success")
         else:
             if not self.braille_document:
                 return
             book = self.braille_document[0]
             self._create_file(book, "{}_braille.brf".format(self.path_name))
+            self._notify_progress_if_increased(100)
             self.on_end("success")
 
     def _create_file(self, file, name):


### PR DESCRIPTION
This pull request introduces progress reporting to the BRF export process, improving user feedback during lengthy operations. The main changes add callbacks to report export progress, update dialogs in the UI with the current percentage, and ensure backward compatibility with previous callback signatures.

**Progress reporting and UI feedback:**

* Added an `on_progress_function` callback to the `WriteBrfFile` class, which is called with the export progress percentage at key stages of the export process. Progress is now reported during file conversion, document cutting, and file writing. (`bnote/apps/edt/edt/write_brf_file.py`) [[1]](diffhunk://#diff-5ca17dca92c312200ed22fc61dc991a3d004c5dbe34e0b445e3d9be9ae6ea101L27-R28) [[2]](diffhunk://#diff-5ca17dca92c312200ed22fc61dc991a3d004c5dbe34e0b445e3d9be9ae6ea101R45-R72) [[3]](diffhunk://#diff-5ca17dca92c312200ed22fc61dc991a3d004c5dbe34e0b445e3d9be9ae6ea101R85-L80) [[4]](diffhunk://#diff-5ca17dca92c312200ed22fc61dc991a3d004c5dbe34e0b445e3d9be9ae6ea101R202-R215)
* Updated the editor UI to display a progress dialog with the current export percentage, replacing the static "exporting..." message with dynamic updates (e.g., "exporting 42%"). (`bnote/apps/edt/editor_app.py`) [[1]](diffhunk://#diff-7205c4a1b91225abf1900133c4ed919c38fb298076079a9ee52dc4ceac300fa6L217-R217) [[2]](diffhunk://#diff-7205c4a1b91225abf1900133c4ed919c38fb298076079a9ee52dc4ceac300fa6R235-R242)

**Backward compatibility:**

* Ensured the new progress callback does not break existing code by detecting if the old `on_end` callback style is used and adapting accordingly. (`bnote/apps/edt/edt/write_brf_file.py`)

These changes collectively enhance the user experience by providing real-time feedback during BRF export operations without disrupting existing integrations.